### PR TITLE
add lucene 6.6.5 to dependencies and fix compile errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@ limitations under the License.
     <Gerrit-ApiVersion>2.16.7</Gerrit-ApiVersion>
     <GitBlit-Version>1.7.1</GitBlit-Version>
     <Wicket-Version>1.4.22</Wicket-Version>
-	<Lucene-Version>6.6.5</Lucene-Version>
+    <Lucene-Version>6.6.5</Lucene-Version>
     <Gerrit-ReloadMode>restart</Gerrit-ReloadMode>
     <Gerrit-InitStep>com.googlesource.gerrit.plugins.gitblit.GitBlitInitStep</Gerrit-InitStep>
     <Gerrit-Module>com.googlesource.gerrit.plugins.gitblit.GitBlitModule</Gerrit-Module>
@@ -71,36 +71,36 @@ limitations under the License.
       <artifactId>wicket-extensions</artifactId>
       <version>${Wicket-Version}</version>
     </dependency>
-   	<dependency>
-		<groupId>org.apache.lucene</groupId>
-		<artifactId>lucene-core</artifactId>
-		<version>${Lucene-Version}</version>
-	</dependency>
-	<dependency>
-		<groupId>org.apache.lucene</groupId>
-		<artifactId>lucene-highlighter</artifactId>
-		<version>${Lucene-Version}</version>
-	</dependency>
-	<dependency>
-		<groupId>org.apache.lucene</groupId>
-		<artifactId>lucene-analyzers-common</artifactId>
-		<version>${Lucene-Version}</version>
-	</dependency>
-	<dependency>
-		<groupId>org.apache.lucene</groupId>
-		<artifactId>lucene-memory</artifactId>
-		<version>${Lucene-Version}</version>
-	</dependency>
-	<dependency>
-		<groupId>org.apache.lucene</groupId>
-		<artifactId>lucene-queryparser</artifactId>
-		<version>${Lucene-Version}</version>
-	</dependency>
-	<dependency>
-		<groupId>org.apache.lucene</groupId>
-		<artifactId>lucene-sandbox</artifactId>
-		<version>${Lucene-Version}</version>
-	</dependency>
+    <dependency>
+      <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-core</artifactId>
+      <version>${Lucene-Version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-highlighter</artifactId>
+      <version>${Lucene-Version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-analyzers-common</artifactId>
+      <version>${Lucene-Version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-memory</artifactId>
+      <version>${Lucene-Version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-queryparser</artifactId>
+      <version>${Lucene-Version}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.lucene</groupId>
+        <artifactId>lucene-sandbox</artifactId>
+        <version>${Lucene-Version}</version>
+    </dependency>
   </dependencies>
   <build>
     <resources>
@@ -156,8 +156,8 @@ limitations under the License.
                   </includes>
                 </resource>
               </resources>
-			</configuration>
-	      </execution>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>
@@ -362,13 +362,13 @@ limitations under the License.
       <id>gerrit-api-repository</id>
       <url>https://gerrit-api.commondatastorage.googleapis.com/release</url>
     </repository>
-	<repository>
-	  <id>com.gitblit</id>
-	  <name>Gitblit</name>
-	  <url>http://gitblit.github.io/gitblit-maven/</url>
-	  <layout>default</layout>
-	</repository>
-	<repository>
+    <repository>
+        <id>com.gitblit</id>
+        <name>Gitblit</name>
+        <url>http://gitblit.github.io/gitblit-maven/</url>
+        <layout>default</layout>
+    </repository>
+    <repository>
       <id>jgit-snapshots</id>
       <url>https://repo.eclipse.org/content/groups/snapshots</url>
     </repository>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@ limitations under the License.
     <Gerrit-ApiVersion>2.16.7</Gerrit-ApiVersion>
     <GitBlit-Version>1.7.1</GitBlit-Version>
     <Wicket-Version>1.4.22</Wicket-Version>
+	<Lucene-Version>6.6.5</Lucene-Version>
     <Gerrit-ReloadMode>restart</Gerrit-ReloadMode>
     <Gerrit-InitStep>com.googlesource.gerrit.plugins.gitblit.GitBlitInitStep</Gerrit-InitStep>
     <Gerrit-Module>com.googlesource.gerrit.plugins.gitblit.GitBlitModule</Gerrit-Module>
@@ -70,6 +71,36 @@ limitations under the License.
       <artifactId>wicket-extensions</artifactId>
       <version>${Wicket-Version}</version>
     </dependency>
+   	<dependency>
+		<groupId>org.apache.lucene</groupId>
+		<artifactId>lucene-core</artifactId>
+		<version>${Lucene-Version}</version>
+	</dependency>
+	<dependency>
+		<groupId>org.apache.lucene</groupId>
+		<artifactId>lucene-highlighter</artifactId>
+		<version>${Lucene-Version}</version>
+	</dependency>
+	<dependency>
+		<groupId>org.apache.lucene</groupId>
+		<artifactId>lucene-analyzers-common</artifactId>
+		<version>${Lucene-Version}</version>
+	</dependency>
+	<dependency>
+		<groupId>org.apache.lucene</groupId>
+		<artifactId>lucene-memory</artifactId>
+		<version>${Lucene-Version}</version>
+	</dependency>
+	<dependency>
+		<groupId>org.apache.lucene</groupId>
+		<artifactId>lucene-queryparser</artifactId>
+		<version>${Lucene-Version}</version>
+	</dependency>
+	<dependency>
+		<groupId>org.apache.lucene</groupId>
+		<artifactId>lucene-sandbox</artifactId>
+		<version>${Lucene-Version}</version>
+	</dependency>
   </dependencies>
   <build>
     <resources>

--- a/src/main/java/com/gitblit/tickets/TicketIndexer.java
+++ b/src/main/java/com/gitblit/tickets/TicketIndexer.java
@@ -29,8 +29,8 @@ import java.util.Set;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field.Store;
-import org.apache.lucene.document.IntField;
-import org.apache.lucene.document.LongField;
+import org.apache.lucene.document.LegacyIntField;
+import org.apache.lucene.document.LegacyLongField;
 import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriter;
@@ -514,15 +514,15 @@ public class TicketIndexer {
 		if (value == null) {
 			return;
 		}
-		doc.add(new LongField(lucene.name(), value.getTime(), Store.YES));
+		doc.add(new LegacyLongField(lucene.name(), value.getTime(), Store.YES));
 	}
 
 	private void toDocField(Document doc, Lucene lucene, long value) {
-		doc.add(new LongField(lucene.name(), value, Store.YES));
+		doc.add(new LegacyLongField(lucene.name(), value, Store.YES));
 	}
 
 	private void toDocField(Document doc, Lucene lucene, int value) {
-		doc.add(new IntField(lucene.name(), value, Store.YES));
+		doc.add(new LegacyIntField(lucene.name(), value, Store.YES));
 	}
 
 	private void toDocField(Document doc, Lucene lucene, String value) {


### PR DESCRIPTION
Lucene search did not work because of missing classes. It seems that it had been compiled against an old lucene version.

Added the same lucene version to the maven dependencies (6.6.5) as used in Gerrit and fixed some compile errors.