### PR TITLE
Fix NPE in LuceneService that occurs whenever defaultBranch is null

### DIFF
--- a/src/main/java/com/gitblit/service/LuceneService.java
+++ b/src/main/java/com/gitblit/service/LuceneService.java
@@ -449,8 +449,11 @@ public class LuceneService implements Runnable {
 					break;
 				}
 			}
-			branches.remove(defaultBranch);
-			branches.add(0, defaultBranch);
+
+			if (defaultBranch != null) {
+				branches.remove(defaultBranch);
+				branches.add(0, defaultBranch);
+			}
 
 			// walk through each branch
 			for (RefModel branch : branches) {
@@ -772,8 +775,11 @@ public class LuceneService implements Runnable {
 					break;
 				}
 			}
-			branches.remove(defaultBranch);
-			branches.add(0, defaultBranch);
+
+			if (defaultBranch != null) {
+				branches.remove(defaultBranch);
+				branches.add(0, defaultBranch);
+			}
 
 			// walk through each branches
 			for (RefModel branch : branches) {


### PR DESCRIPTION
That NPE happens for all Gerrit projects, that have no branches,
e.g. All-Projects, and no default branch, when generation
of a Lucene index is configured globally for all projects by setting:

gitblit.indexbranch=refs/heads/master

in the global Git settings.