### PR TITLE
Change markdown parser options to avoid hardwraps

### DIFF
--- a/src/main/java/com/gitblit/utils/MarkdownUtils.java
+++ b/src/main/java/com/gitblit/utils/MarkdownUtils.java
@@ -19,6 +19,7 @@ import static com.vladsch.flexmark.ext.wikilink.WikiLinkExtension.WIKI_LINK;
 import static com.vladsch.flexmark.profiles.pegdown.Extensions.ALL;
 import static com.vladsch.flexmark.profiles.pegdown.Extensions.ANCHORLINKS;
 import static com.vladsch.flexmark.profiles.pegdown.Extensions.SMARTYPANTS;
+import static com.vladsch.flexmark.profiles.pegdown.Extensions.HARDWRAPS;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -92,9 +93,9 @@ public class MarkdownUtils {
 		MutableDataHolder options;
 
 		if (linkRenderer == null) {
-			options = PegdownOptionsAdapter.flexmarkOptions(ALL & ~SMARTYPANTS & ~ANCHORLINKS).toMutable();
+			options = PegdownOptionsAdapter.flexmarkOptions(ALL & ~SMARTYPANTS & ~ANCHORLINKS & ~HARDWRAPS).toMutable();
 		} else {
-			options = PegdownOptionsAdapter.flexmarkOptions(ALL & ~SMARTYPANTS & ~ANCHORLINKS, new CustomExtension(linkRenderer)).toMutable();
+			options = PegdownOptionsAdapter.flexmarkOptions(ALL & ~SMARTYPANTS & ~ANCHORLINKS & ~HARDWRAPS, new CustomExtension(linkRenderer)).toMutable();
 		}
 		Node document = Parser.builder(options).build().parse(markdown);
 		return HtmlRenderer.builder(options).build().render(document);


### PR DESCRIPTION
Hardwraps as Github introduced them to markdown do not make sense to all markdown users. People using semantic line breaks in Markdown will get ugly Markdown rendering, when hardwraps are active.

I suggest to disable hardwraps.