### PR TITLE
update dependencies for Gerrit 3.0.1

### DIFF
--- a/docu/index.md
+++ b/docu/index.md
@@ -5,7 +5,7 @@ with full SSO through Gerrit.
 
 * License: [Apache Public License 2.0](http://www.apache.org/licenses/LICENSE-2.0)
 * [Home page](https://github.com/tomaswolf/gerrit-gitblit-plugin)
-* Installed plugin version: <em id='gerrit-gitblit-current-version'>2.16.171.2-SNAPSHOT</em> &mdash; <a id='gerrit-gitblit-version-check' style='display:none;' href='#'>Check for updates</a>
+* Installed plugin version: <em id='gerrit-gitblit-current-version'>3.0.171.2-SNAPSHOT</em> &mdash; <a id='gerrit-gitblit-version-check' style='display:none;' href='#'>Check for updates</a>
 
 For a list of contributors, see at [GitHub](https://github.com/tomaswolf/gerrit-gitblit-plugin/graphs/contributors).
 
@@ -92,6 +92,6 @@ Report bugs or make feature requests at the [GitHub issue tracker](https://githu
 
 <hr style="color: #C0C0C0; background-color: #C0C0C0; border-color: #C0C0C0; height: 2px;" />
 <div style="float:right;">
-<a href="https://github.com/tomaswolf/gerrit-gitblit-plugin" target="_blank">GitBlit plugin 2.16.171.2-SNAPSHOT</a>
+<a href="https://github.com/tomaswolf/gerrit-gitblit-plugin" target="_blank">GitBlit plugin 3.0.171.2-SNAPSHOT</a>
 </div>
 <script type="text/javascript" src="version_check.js"></script>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
   <artifactId>gitblit-plugin</artifactId>
   <description>GitBlit for Gerrit integrated as a plugin</description>
   <name>Gerrit - GitBlit Plugin</name>
-  <version>2.16.171.2-SNAPSHOT</version><!-- Gerrit API version followed by collapsed GitBlit version, followed by plugin version -->
+  <version>3.0.171.2-SNAPSHOT</version><!-- Gerrit API version followed by collapsed GitBlit version, followed by plugin version -->
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -29,7 +29,7 @@ limitations under the License.
   </licenses>
   <properties>
     <Gerrit-ApiType>plugin</Gerrit-ApiType>
-    <Gerrit-ApiVersion>2.16.7</Gerrit-ApiVersion>
+    <Gerrit-ApiVersion>3.0.1</Gerrit-ApiVersion>
     <GitBlit-Version>1.7.1</GitBlit-Version>
     <Wicket-Version>1.4.22</Wicket-Version>
     <Lucene-Version>6.6.5</Lucene-Version>


### PR DESCRIPTION
Known issue: Gerrit UI won't show correctly
after using the back button in Browser.

Workaround: refresh page after using the back button. 